### PR TITLE
Pri 50 video interview - grade second

### DIFF
--- a/public/interviews.json
+++ b/public/interviews.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "1",
+    "title": "Интервью 1",
+    "src": "https://www.youtube.com/watch?v=PLwrvZahiO4"
+  },
+  {
+    "id": "2",
+    "title": "Интервью 2",
+    "src": "https://www.youtube.com/watch?v=MdRE18dGmNU"
+  },
+  {
+    "id": "3",
+    "title": "Интервью 3",
+    "src": "https://www.youtube.com/watch?v=PLwrvZahiO4"
+  },
+  {
+    "id": "4",
+    "title": "Интервью 4",
+    "src": "https://www.youtube.com/watch?v=PLwrvZahiO4"
+  }
+]

--- a/public/interviews.json
+++ b/public/interviews.json
@@ -38,8 +38,8 @@
   {
     "id": "7",
     "title": "Интервью 7",
-    "src": "https://youtu.be/_8qr7dK4A2g?si=7IhrJ1d7z99uuFpl",
-    "youtubeId": "_8qr7dK4A2g"
+    "src": "https://youtu.be/ezcYbYchx1U?si=SnjOTcXPmlAYoPSj",
+    "youtubeId": "ezcYbYchx1U"
   },
   {
     "id": "8",

--- a/public/interviews.json
+++ b/public/interviews.json
@@ -16,5 +16,47 @@
     "title": "Интервью 3",
     "src": "https://www.youtube.com/embed/_8qr7dK4A2g?si=Z9YpSPY1QVIAkVAc",
     "youtubeId": "_8qr7dK4A2g"
+  },
+  {
+    "id": "4",
+    "title": "Интервью 4",
+    "src": "https://www.youtube.com/live/8PIpHPftlpk?si=YO2Vv_x2aw2FqRRX",
+    "youtubeId": "8PIpHPftlpk"
+  },
+  {
+    "id": "5",
+    "title": "Интервью 5",
+    "src": "https://www.youtube.com/live/O1W76kdAUwY?si=Kh2rweZpmrr6Puv1",
+    "youtubeId": "O1W76kdAUwY"
+  },
+  {
+    "id": "6",
+    "title": "Интервью 6",
+    "src": "https://www.youtube.com/live/27krhiZ06_E?si=enX5gXZsiGDkuf15",
+    "youtubeId": "27krhiZ06_E"
+  },
+  {
+    "id": "7",
+    "title": "Интервью 7",
+    "src": "https://youtu.be/_8qr7dK4A2g?si=7IhrJ1d7z99uuFpl",
+    "youtubeId": "_8qr7dK4A2g"
+  },
+  {
+    "id": "8",
+    "title": "Интервью 8",
+    "src": "https://youtu.be/kYnSZTKL_tY?si=7ldeAqvqADZq2crV",
+    "youtubeId": "kYnSZTKL_tY"
+  },
+  {
+    "id": "9",
+    "title": "Интервью 9",
+    "src": "https://youtu.be/j_4U1CoFWWQ?si=0i6XdG-3Cy5HMLUw",
+    "youtubeId": "j_4U1CoFWWQ"
+  },
+  {
+    "id": "10",
+    "title": "Интервью 10",
+    "src": "https://youtu.be/LhHXcgbz3Z4?si=yvSH_EqfOWz4exs7",
+    "youtubeId": "LhHXcgbz3Z4"
   }
 ]

--- a/public/interviews.json
+++ b/public/interviews.json
@@ -2,21 +2,19 @@
   {
     "id": "1",
     "title": "Интервью 1",
-    "src": "https://www.youtube.com/watch?v=PLwrvZahiO4"
+    "src": "https://www.youtube.com/embed/fNhEAnp3ntw?si=jg_kfktM0tjBDxBQ",
+    "youtubeId": "fNhEAnp3ntw"
   },
   {
     "id": "2",
     "title": "Интервью 2",
-    "src": "https://www.youtube.com/watch?v=MdRE18dGmNU"
+    "src": "https://www.youtube.com/embed/25lCunO6yDQ?si=6rI3uAHFn-elUeOb",
+    "youtubeId": "25lCunO6yDQ"
   },
   {
     "id": "3",
     "title": "Интервью 3",
-    "src": "https://www.youtube.com/watch?v=PLwrvZahiO4"
-  },
-  {
-    "id": "4",
-    "title": "Интервью 4",
-    "src": "https://www.youtube.com/watch?v=PLwrvZahiO4"
+    "src": "https://www.youtube.com/embed/_8qr7dK4A2g?si=Z9YpSPY1QVIAkVAc",
+    "youtubeId": "_8qr7dK4A2g"
   }
 ]

--- a/src/Components/GradeContents/GradeContents.jsx
+++ b/src/Components/GradeContents/GradeContents.jsx
@@ -8,9 +8,11 @@ export default function GradeContents({
   videoPath,
   theoryPath,
   testsPath,
+  interviewPath,
   videoDescription,
   theoryDescription,
   testsDescription,
+  interviewDescription,
 }) {
   return (
     <div className="grading">
@@ -74,6 +76,25 @@ export default function GradeContents({
           </div>
           <div>{testsDescription}</div>
           <Link className="button" to={testsPath}>
+            Начать
+          </Link>
+        </div>
+        <div className="grading__container_block">
+          <h2 className="grading__container_title">
+            Собеседования
+          </h2>
+          <div className="progressBar">
+            <div className="progressBar__title">
+              <span>Пройдено: </span>
+              <span className="progressBar__value">30</span>
+              <span>%</span>
+            </div>
+            <div className="progressBar__outer">
+              <div className="progressBar__inner"></div>
+            </div>
+          </div>
+          <p>{interviewDescription}</p>
+          <Link className="button" to={interviewPath}>
             Начать
           </Link>
         </div>

--- a/src/Components/GradeContents/GradeContents.jsx
+++ b/src/Components/GradeContents/GradeContents.jsx
@@ -8,11 +8,9 @@ export default function GradeContents({
   videoPath,
   theoryPath,
   testsPath,
-  interviewPath,
   videoDescription,
   theoryDescription,
   testsDescription,
-  interviewDescription,
 }) {
   return (
     <div className="grading">
@@ -76,25 +74,6 @@ export default function GradeContents({
           </div>
           <div>{testsDescription}</div>
           <Link className="button" to={testsPath}>
-            Начать
-          </Link>
-        </div>
-        <div className="grading__container_block">
-          <h2 className="grading__container_title">
-            Собеседования
-          </h2>
-          <div className="progressBar">
-            <div className="progressBar__title">
-              <span>Пройдено: </span>
-              <span className="progressBar__value">30</span>
-              <span>%</span>
-            </div>
-            <div className="progressBar__outer">
-              <div className="progressBar__inner"></div>
-            </div>
-          </div>
-          <p>{interviewDescription}</p>
-          <Link className="button" to={interviewPath}>
             Начать
           </Link>
         </div>

--- a/src/Components/IframePlayer/IframePlayer.jsx
+++ b/src/Components/IframePlayer/IframePlayer.jsx
@@ -16,6 +16,7 @@ function IframePlayer({ currentVideo }) {
           onStateChange: onPlayerStateChange,
         },
       });
+      setIsEnded(false);
     };
 
     // Загрузка YouTube IFrame API

--- a/src/Components/IframePlayer/IframePlayer.jsx
+++ b/src/Components/IframePlayer/IframePlayer.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from "react";
+import "./IframePlayer.scss";
+import star from "../../assets/images/background_star.svg";
+import IframePlayerPagination from "./IframePlayerPagination";
+
+function IframePlayer({ currentVideo }) {
+  const playerRef = useRef(null);
+  const [isEnded, setIsEnded] = useState(false);
+
+  useEffect(() => {
+    // Инициализации YouTube плеера
+    const onYouTubeIframeAPIReady = () => {
+      playerRef.current = new YT.Player("youtube-player", {
+        videoId: currentVideo,
+        events: {
+          onStateChange: onPlayerStateChange,
+        },
+      });
+    };
+
+    // Загрузка YouTube IFrame API
+    if (!window.YT) {
+      const tag = document.createElement("script");
+      tag.src = "https://www.youtube.com/iframe_api";
+      const firstScriptTag =
+        document.getElementsByTagName("script")[0];
+      firstScriptTag.parentNode.insertBefore(
+        tag,
+        firstScriptTag,
+      );
+      window.onYouTubeIframeAPIReady =
+        onYouTubeIframeAPIReady;
+    } else {
+      onYouTubeIframeAPIReady();
+    }
+
+    // Очистка при изменении видео
+    return () => {
+      if (playerRef.current) {
+        playerRef.current.destroy();
+      }
+    };
+  }, [currentVideo]);
+
+  //Функция отслеживания завершения видео
+  const onPlayerStateChange = event => {
+    if (event.data === YT.PlayerState.ENDED) {
+      handleEnded();
+    }
+  };
+
+  const handleEnded = () => {
+    setIsEnded(true);
+  };
+
+  return (
+    <div className="video__container">
+      <img
+        className="bg-image__star"
+        src={star}
+        alt="star_video"
+      />
+      <div id="youtube-player"></div>
+      <IframePlayerPagination isEnded={isEnded} />
+    </div>
+  );
+}
+
+export default IframePlayer;

--- a/src/Components/IframePlayer/IframePlayer.jsx
+++ b/src/Components/IframePlayer/IframePlayer.jsx
@@ -3,7 +3,11 @@ import "./IframePlayer.scss";
 import star from "../../assets/images/background_star.svg";
 import IframePlayerPagination from "./IframePlayerPagination";
 
-function IframePlayer({ currentVideo }) {
+function IframePlayer({
+  currentVideo,
+  pagePath,
+  gradingPath,
+}) {
   const playerRef = useRef(null);
   const [isEnded, setIsEnded] = useState(false);
 
@@ -62,7 +66,7 @@ function IframePlayer({ currentVideo }) {
         alt="star_video"
       />
       <div id="youtube-player"></div>
-      <IframePlayerPagination isEnded={isEnded} />
+      <IframePlayerPagination isEnded={isEnded} pagePath={pagePath} gradingPath={gradingPath}/>
     </div>
   );
 }

--- a/src/Components/IframePlayer/IframePlayer.scss
+++ b/src/Components/IframePlayer/IframePlayer.scss
@@ -18,6 +18,7 @@
     max-width: 100%;
     height: auto;
     border-radius: 16px;
+    background-color: $blackcolor;
   }
 
   .video {

--- a/src/Components/IframePlayer/IframePlayer.scss
+++ b/src/Components/IframePlayer/IframePlayer.scss
@@ -1,0 +1,89 @@
+@import "../../style/vars.scss";
+@import "../../style/template.scss";
+
+.video__container {
+  padding: 40px 40px 0 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: $whitecolor;
+  gap: 35px;
+  align-items: center;
+  position: relative;
+  box-shadow: $inner-boxshadow;
+
+  #youtube-player {
+    width: 80%;
+    aspect-ratio: 16 / 9;
+    max-width: 100%;
+    height: auto;
+    border-radius: 16px;
+  }
+
+  .video {
+    &__nav {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      align-items: start;
+    }
+
+    &__button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      cursor: pointer;
+      color: $whitecolor;
+      background: $pinkcolor;
+      border: none;
+      border-radius: 50px;
+      font-size: 16px;
+      padding: 4px 24px;
+      min-width: 200px;
+      text-decoration: none;
+
+      &:hover {
+        background: $grey;
+      }
+
+      &.disabled {
+        cursor: unset;
+        background: rgba($color: $pinkcolor, $alpha: 0.7);
+      }
+    }
+  }
+
+  .bg-image__cat {
+    width: 100%;
+  }
+  .bg-image__star {
+    position: absolute;
+    top: 30px;
+    right: 20px;
+  }
+}
+
+@media screen and (max-width: 950px) {
+  .video__container {
+    background-color: transparent;
+    margin-top: 30px;
+    padding: 0;
+    box-shadow: none;
+    border-radius: 0;
+
+    .video__button {
+      font-size: 8px;
+      padding: 4px 12px;
+      min-width: 110px;
+      margin: 0 20px;
+
+      & img {
+        width: 16px;
+      }
+    }
+    .bg-image__cat,
+    .bg-image__star {
+      display: none;
+    }
+  }
+}

--- a/src/Components/IframePlayer/IframePlayerPagination.jsx
+++ b/src/Components/IframePlayer/IframePlayerPagination.jsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import "./IframePlayer.scss";
+import prev from "../../assets/images/video_arr-prev.svg";
+import next from "../../assets/images/video_arr-next.svg";
+import check from "../../assets/images/video_checked.svg";
+import catBottomPic from "../../assets/images/background_cat-video.svg";
+import { useSelector } from "react-redux";
+
+function IframePlayerPagination({ isEnded }) {
+  const [hasWatched, setHasWatched] = useState(false);
+  const data = useSelector(
+    state => state.interviews.interviews,
+  );
+  const { id } = useParams();
+  const currentVideo = parseInt(id, 10);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setHasWatched(false);
+  }, [id]);
+
+  const handleCheck = () => {
+    if (isEnded) setHasWatched(true);
+  };
+
+  const handlePrev = () => {
+    if (currentVideo > 1) {
+      navigate(
+        `/gradingsecond/interviewsecond/${
+          currentVideo - 1
+        }`,
+      );
+    }
+  };
+
+  const handleNext = () => {
+    if (currentVideo < data.length) {
+      navigate(
+        `/gradingsecond/interviewsecond/${
+          currentVideo + 1
+        }`,
+      );
+    }
+  };
+
+  const watchingBtn = (
+    <button
+      className={`video__button ${
+        !isEnded ? "disabled" : ""
+      }`}
+      disabled={!isEnded}
+      onClick={handleCheck}
+    >
+      <img src={check} alt="video-checked" />
+      <p>Я посмотрела</p>
+    </button>
+  );
+
+  const watchedBtn = (
+    <button
+      className={`video__button ${
+        currentVideo === data.length ? "disabled" : ""
+      }`}
+      disabled={currentVideo === data.length}
+      onClick={handleNext}
+    >
+      <img src={next} alt="video-next" />
+      <p>Следующее видео</p>
+    </button>
+  );
+
+  const prevBtn = (
+    <button
+      className={`video__button ${
+        currentVideo === 1 ? "disabled" : ""
+      }`}
+      onClick={handlePrev}
+      disabled={currentVideo === 1}
+    >
+      <img src={prev} alt="video-prev" />
+      <p>Предыдущее видео</p>
+    </button>
+  );
+
+  const catImg = (
+    <div className="video__cat">
+      <img
+        className="bg-image__cat"
+        src={catBottomPic}
+        alt="video_cat"
+      />
+    </div>
+  );
+
+  return (
+    <div className="video__nav">
+      {prevBtn}
+      {catImg}
+      {hasWatched ? watchedBtn : watchingBtn}
+    </div>
+  );
+}
+
+export default IframePlayerPagination;

--- a/src/Components/IframePlayer/IframePlayerPagination.jsx
+++ b/src/Components/IframePlayer/IframePlayerPagination.jsx
@@ -7,7 +7,11 @@ import check from "../../assets/images/video_checked.svg";
 import catBottomPic from "../../assets/images/background_cat-video.svg";
 import { useSelector } from "react-redux";
 
-function IframePlayerPagination({ isEnded }) {
+function IframePlayerPagination({
+  isEnded,
+  pagePath,
+  gradingPath,
+}) {
   const [hasWatched, setHasWatched] = useState(false);
   const data = useSelector(
     state => state.interviews.interviews,
@@ -27,9 +31,7 @@ function IframePlayerPagination({ isEnded }) {
   const handlePrev = () => {
     if (currentVideo > 1) {
       navigate(
-        `/gradingsecond/interviewsecond/${
-          currentVideo - 1
-        }`,
+        `/${gradingPath}/${pagePath}/${currentVideo - 1}`,
       );
     }
   };
@@ -37,9 +39,7 @@ function IframePlayerPagination({ isEnded }) {
   const handleNext = () => {
     if (currentVideo < data.length) {
       navigate(
-        `/gradingsecond/interviewsecond/${
-          currentVideo + 1
-        }`,
+        `/${gradingPath}/${pagePath}/${currentVideo + 1}`,
       );
     }
   };

--- a/src/Components/ThemeNavBar/ThemeNavBar.jsx
+++ b/src/Components/ThemeNavBar/ThemeNavBar.jsx
@@ -10,6 +10,7 @@ function ThemeNavBar({
   error,
   status,
   pagePath,
+  gradingPath,
   toggleNavBar = () => {},
 }) {
   const [isMobile, setIsMobile] = useState(false);
@@ -58,7 +59,11 @@ function ThemeNavBar({
         >
           <img src={close} alt="close" />
         </button>
-        <ThemeNavBarInner data={data} pagePath={pagePath} />
+        <ThemeNavBarInner
+          data={data}
+          pagePath={pagePath}
+          gradingPath={gradingPath}
+        />
       </div>
     </div>
   );
@@ -81,6 +86,7 @@ function ThemeNavBar({
         data={data}
         pagePath={pagePath}
         navBarIsHidden={navBarIsHidden}
+        gradingPath={gradingPath}
       />
     </div>
   );

--- a/src/Components/ThemeNavBar/ThemeNavBar.scss
+++ b/src/Components/ThemeNavBar/ThemeNavBar.scss
@@ -91,12 +91,12 @@
 }
 
 .mobile__close_btn {
-  background-color: transparent;
+  background-color: $pinkcolor;
   border: $pinkcolor 1px solid;
   border-radius: 50%;
   position: absolute;
   right: 0;
-  top: -20%;
+  top: -30%;
 
   & img {
     width: 16px;

--- a/src/Components/ThemeNavBar/ThemeNavBarInner.jsx
+++ b/src/Components/ThemeNavBar/ThemeNavBarInner.jsx
@@ -2,7 +2,12 @@ import "./ThemeNavBar.scss";
 import check from "../../assets/images/video_checked.svg";
 import ThemeNavBarLink from "./ThemeNavBarLink";
 
-function ThemeNavBar({ data, pagePath, navBarIsHidden }) {
+function ThemeNavBar({
+  data,
+  pagePath,
+  gradingPath,
+  navBarIsHidden,
+}) {
   return (
     <div
       className={
@@ -18,6 +23,7 @@ function ThemeNavBar({ data, pagePath, navBarIsHidden }) {
               pagePath={pagePath}
               itemId={item.id}
               itemTitle={item.title}
+              gradingPath={gradingPath}
             />
 
             {item.isFinished && (

--- a/src/Components/ThemeNavBar/ThemeNavBarLink.jsx
+++ b/src/Components/ThemeNavBar/ThemeNavBarLink.jsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import "./ThemeNavBar.scss";
 
-function ThemeNavBarLink({ pagePath, itemId, itemTitle }) {
+function ThemeNavBarLink({
+  pagePath,
+  itemId,
+  itemTitle,
+  gradingPath,
+}) {
   const [active, setActive] = useState(false);
   const { id } = useParams();
 
@@ -12,7 +17,7 @@ function ThemeNavBarLink({ pagePath, itemId, itemTitle }) {
 
   return (
     <Link
-      to={`/gradingfirst/${pagePath}/${itemId}`}
+      to={`/${gradingPath}/${pagePath}/${itemId}`}
       className={`theme__item_link ${
         active ? "active" : ""
       }`}

--- a/src/Components/VideoPlayer/VideoPlayer.jsx
+++ b/src/Components/VideoPlayer/VideoPlayer.jsx
@@ -4,7 +4,7 @@ import VideoPlayerPagination from "./VideoPlayerPagination.jsx";
 import "./VideoPlayer.scss";
 import star from "../../assets/images/background_star.svg";
 
-function VideoPlayer({ src }) {
+function VideoPlayer({ src, pagePath, gradingPath }) {
   const videoRef = useRef(null);
   const [isEnded, setIsEnded] = useState(false);
 
@@ -38,7 +38,11 @@ function VideoPlayer({ src }) {
         alt="star_video"
       />
       <VideoPlayerInner src={src} videoRef={videoRef} />
-      <VideoPlayerPagination isEnded={isEnded} />
+      <VideoPlayerPagination
+        isEnded={isEnded}
+        pagePath={pagePath}
+        gradingPath={gradingPath}
+      />
     </div>
   );
 }

--- a/src/Components/VideoPlayer/VideoPlayerPagination.jsx
+++ b/src/Components/VideoPlayer/VideoPlayerPagination.jsx
@@ -7,7 +7,11 @@ import check from "../../assets/images/video_checked.svg";
 import catBottomPic from "../../assets/images/background_cat-video.svg";
 import { useSelector } from "react-redux";
 
-function VideoPlayerPagination({ isEnded }) {
+function VideoPlayerPagination({
+  isEnded,
+  pagePath,
+  gradingPath,
+}) {
   const [hasWatched, setHasWatched] = useState(false);
   const data = useSelector(state => state.videos.videos);
   const { id } = useParams();
@@ -25,7 +29,7 @@ function VideoPlayerPagination({ isEnded }) {
   const handlePrev = () => {
     if (currentVideo > 1) {
       navigate(
-        `/gradingfirst/videofirst/${currentVideo - 1}`,
+        `/${gradingPath}/${pagePath}/${currentVideo - 1}`,
       );
     }
   };
@@ -33,7 +37,7 @@ function VideoPlayerPagination({ isEnded }) {
   const handleNext = () => {
     if (currentVideo < data.length) {
       navigate(
-        `/gradingfirst/videofirst/${currentVideo + 1}`,
+        `/${gradingPath}/${pagePath}/${currentVideo + 1}`,
       );
     }
   };

--- a/src/Pages/GradingFirst/VideoFirst/VideoFirst.jsx
+++ b/src/Pages/GradingFirst/VideoFirst/VideoFirst.jsx
@@ -64,6 +64,7 @@ export default function VideoFirst() {
             error={error}
             status={status}
             pagePath="videofirst"
+            gradingPath="gradingfirst"
             toggleNavBar={toggleNavBar}
           />
           <Outlet />

--- a/src/Pages/GradingFirst/VideoFirst/VideoFirstItem.jsx
+++ b/src/Pages/GradingFirst/VideoFirst/VideoFirstItem.jsx
@@ -24,5 +24,11 @@ export default function VideoFirstItem() {
     return <div>Невозможно загрузить видео...</div>;
   if (!data) return <div>Видео не найдены</div>;
 
-  return <VideoPlayer src={video.src} />;
+  return (
+    <VideoPlayer
+      src={video.src}
+      pagePath="videofirst"
+      gradingPath="gradingfirst"
+    />
+  );
 }

--- a/src/Pages/GradingSecond/GradingSecond.jsx
+++ b/src/Pages/GradingSecond/GradingSecond.jsx
@@ -1,5 +1,31 @@
-import "./GradingSecond.scss";
+import { Outlet, useLocation } from "react-router-dom";
+import GradeContents from "../../Components/GradeContents/GradeContents";
 
 export default function GradingSecond() {
-  return <div>GradingSecond</div>;
+  const location = useLocation();
+
+  const showNavigation =
+    location.pathname === "/gradingsecond";
+
+  const interviewPath = "interviewsecond";
+  const description = "Lorem...";
+  return (
+    <div>
+      {showNavigation && (
+        <GradeContents
+          grading="Градация 2"
+          gradeDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit."
+          videoPath="/"
+          theoryPath="/"
+          testsPath="/"
+          interviewPath="interviewsecond"
+          videoDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
+          theoryDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
+          testsDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
+          interviewDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
+        />
+      )}
+      <Outlet />
+    </div>
+  );
 }

--- a/src/Pages/GradingSecond/GradingSecond.jsx
+++ b/src/Pages/GradingSecond/GradingSecond.jsx
@@ -1,29 +1,20 @@
-import { Outlet, useLocation } from "react-router-dom";
-import GradeContents from "../../Components/GradeContents/GradeContents";
+import {
+  Outlet,
+  useLocation,
+  Link,
+} from "react-router-dom";
 
 export default function GradingSecond() {
   const location = useLocation();
-
   const showNavigation =
     location.pathname === "/gradingsecond";
 
-  const interviewPath = "interviewsecond";
-  const description = "Lorem...";
   return (
     <div>
       {showNavigation && (
-        <GradeContents
-          grading="Градация 2"
-          gradeDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit."
-          videoPath="/"
-          theoryPath="/"
-          testsPath="/"
-          interviewPath="interviewsecond"
-          videoDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
-          theoryDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
-          testsDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
-          interviewDescription="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida."
-        />
+        <Link className="button" to="interviewsecond">
+          Собеседования
+        </Link>
       )}
       <Outlet />
     </div>

--- a/src/Pages/GradingSecond/InterviewSecond/InterviewSecond.jsx
+++ b/src/Pages/GradingSecond/InterviewSecond/InterviewSecond.jsx
@@ -1,13 +1,79 @@
-import { NavLink } from "react-router-dom";
+import {
+  Link,
+  Outlet,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import "./InterviewSecond.scss";
+import { fetchInterviews } from "../../../Services/fetchInterviews.js";
+import ThemeNavBar from "../../../Components/ThemeNavBar/ThemeNavBar.jsx";
 
-export default function InterviewSecond() {
+export default function VideoFirst() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const videos = useSelector(
+    state => state.interviews.interviews,
+  );
+  const status = useSelector(
+    state => state.interviews.status,
+  );
+  const error = useSelector(
+    state => state.interviews.error,
+  );
+  const { pathname } = useLocation();
+  const [navBarIsHidden, setNavBarIsHidden] =
+    useState(false);
+
+  useEffect(() => {
+    if (status === "idle") {
+      dispatch(fetchInterviews());
+    }
+  }, [dispatch, status]);
+
+  useEffect(() => {
+    if (
+      videos.length > 0 &&
+      pathname === "/gradingsecond/interviewsecond"
+    ) {
+      navigate("/gradingsecond/interviewsecond/1", {
+        replace: true,
+      });
+    }
+  }, [videos, pathname, navigate]);
+
+  const toggleNavBar = () => {
+    setNavBarIsHidden(!navBarIsHidden);
+  };
+
   return (
-    <div className="container-interview">
-      <div className="title-interview">
-        <NavLink to="#">
-          Вернуться из интервью к градации
-        </NavLink>
+    <div>
+      <div className="videoPage">
+        <div className="videoPage__title">
+          <Link
+            className="videoPage__mainlink"
+            to="/gradingsecond"
+          >
+            Вернуться назад к градации
+          </Link>
+        </div>
+        <div
+          className={
+            navBarIsHidden
+              ? "videoPage__main__modified"
+              : "videoPage__main"
+          }
+        >
+          <ThemeNavBar
+            data={videos || []}
+            error={error}
+            status={status}
+            pagePath="interviewsecond"
+            toggleNavBar={toggleNavBar}
+          />
+          <Outlet />
+        </div>
       </div>
     </div>
   );

--- a/src/Pages/GradingSecond/InterviewSecond/InterviewSecond.jsx
+++ b/src/Pages/GradingSecond/InterviewSecond/InterviewSecond.jsx
@@ -70,6 +70,7 @@ export default function VideoFirst() {
             error={error}
             status={status}
             pagePath="interviewsecond"
+            gradingPath="gradingsecond"
             toggleNavBar={toggleNavBar}
           />
           <Outlet />

--- a/src/Pages/GradingSecond/InterviewSecond/InterviewSecond.jsx
+++ b/src/Pages/GradingSecond/InterviewSecond/InterviewSecond.jsx
@@ -1,0 +1,14 @@
+import { NavLink } from "react-router-dom";
+import "./InterviewSecond.scss";
+
+export default function InterviewSecond() {
+  return (
+    <div className="container-interview">
+      <div className="title-interview">
+        <NavLink to="#">
+          Вернуться из интервью к градации
+        </NavLink>
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/GradingSecond/InterviewSecond/InterviewSecondItem.jsx
+++ b/src/Pages/GradingSecond/InterviewSecond/InterviewSecondItem.jsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router-dom";
+import IframePlayer from "../../../Components/IframePlayer/IframePlayer";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+
+export default function InterviewSecondItem() {
+  const { id } = useParams();
+  const data = useSelector(
+    state => state.interviews.interviews,
+  );
+  const status = useSelector(
+    state => state.interviews.status,
+  );
+  const error = useSelector(
+    state => state.interviews.error,
+  );
+
+  const [video, setVideo] = useState({});
+
+  useEffect(() => {
+    if (data && id) {
+      const newVideo = data.find(item => item.id === id);
+      setVideo(newVideo);
+    }
+  }, [data, id]);
+
+  if (status === "loading")
+    return <div>Загрузка видео...</div>;
+  if (status === "failed" || error)
+    return <div>Невозможно загрузить видео...</div>;
+  if (!data) return <div>Видео не найдены</div>;
+
+  return <IframePlayer currentVideo={video.youtubeId} />;
+}

--- a/src/Pages/GradingSecond/InterviewSecond/InterviewSecondItem.jsx
+++ b/src/Pages/GradingSecond/InterviewSecond/InterviewSecondItem.jsx
@@ -30,5 +30,11 @@ export default function InterviewSecondItem() {
     return <div>Невозможно загрузить видео...</div>;
   if (!data) return <div>Видео не найдены</div>;
 
-  return <IframePlayer currentVideo={video.youtubeId} />;
+  return (
+    <IframePlayer
+      currentVideo={video.youtubeId}
+      pagePath="interviewsecond"
+      gradingPath="gradingsecond"
+    />
+  );
 }

--- a/src/Pages/RootLayout/RootLayout.jsx
+++ b/src/Pages/RootLayout/RootLayout.jsx
@@ -20,16 +20,19 @@ export default function RootLayout() {
     dispatch({ type: "SUBSCRIBE_TO_USERS" });
   }, [dispatch]);
 
-  // useEffect(() => {
-  //   onAuthStateChanged(auth,(user)=>{
-  //     if(user){
-  //       dispatch({ type: "SUBSCRIBE_TO_USER",emailUser:user.email});
-  //       navigate("/home");
-  //       return
-  //     }
-  //     navigate('login')
-  //   })
-  // }, []);
+  useEffect(() => {
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        dispatch({
+          type: "SUBSCRIBE_TO_USER",
+          emailUser: user.email,
+        });
+        navigate("/home");
+        return;
+      }
+      navigate("login");
+    });
+  }, []);
 
   useEffect(() => {
     if (

--- a/src/Pages/RootLayout/RootLayout.jsx
+++ b/src/Pages/RootLayout/RootLayout.jsx
@@ -1,38 +1,35 @@
 import "./RootLayout.scss";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Header from "../../Components/Header/Header";
 import { useLocation } from "react-router-dom";
 import { Outlet } from "react-router-dom";
 import { useEffect, useState } from "react";
-import {useDispatch, useSelector} from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 export default function RootLayout() {
   const [flag, setFlag] = useState(true);
-  const [loader,setLoader] = useState(false);
+  const [loader, setLoader] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
-
 
   const auth = getAuth();
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch({ type: "SUBSCRIBE_TO_USERS",});
-
+    dispatch({ type: "SUBSCRIBE_TO_USERS" });
   }, [dispatch]);
 
-
-  useEffect(() => {
-    onAuthStateChanged(auth,(user)=>{
-      if(user){
-        dispatch({ type: "SUBSCRIBE_TO_USER",emailUser:user.email});
-        navigate("/home");
-        return
-      }
-      navigate('login')
-    })
-  }, []);
+  // useEffect(() => {
+  //   onAuthStateChanged(auth,(user)=>{
+  //     if(user){
+  //       dispatch({ type: "SUBSCRIBE_TO_USER",emailUser:user.email});
+  //       navigate("/home");
+  //       return
+  //     }
+  //     navigate('login')
+  //   })
+  // }, []);
 
   useEffect(() => {
     if (
@@ -45,8 +42,6 @@ export default function RootLayout() {
     }
     setFlag(true);
   }, [location.pathname]);
-
-
 
   return (
     <div>

--- a/src/Pages/index.js
+++ b/src/Pages/index.js
@@ -13,6 +13,7 @@ import Profile from "./Profile/Profile";
 import VideoFirst from "./GradingFirst/VideoFirst/VideoFirst";
 import VideoFirstItem from "./GradingFirst/VideoFirst/VideoFirstItem";
 import InterviewSecond from "./GradingSecond/InterviewSecond/InterviewSecond";
+import InterviewSecondItem from "./GradingSecond/InterviewSecond/InterviewSecondItem";
 
 export {
   RootLayout,
@@ -30,4 +31,5 @@ export {
   VideoFirst,
   VideoFirstItem,
   InterviewSecond,
+  InterviewSecondItem,
 };

--- a/src/Pages/index.js
+++ b/src/Pages/index.js
@@ -12,6 +12,7 @@ import Instructions from "./Instructions/Instructions";
 import Profile from "./Profile/Profile";
 import VideoFirst from "./GradingFirst/VideoFirst/VideoFirst";
 import VideoFirstItem from "./GradingFirst/VideoFirst/VideoFirstItem";
+import InterviewSecond from "./GradingSecond/InterviewSecond/InterviewSecond";
 
 export {
   RootLayout,
@@ -28,4 +29,5 @@ export {
   Profile,
   VideoFirst,
   VideoFirstItem,
+  InterviewSecond,
 };

--- a/src/Services/fetchInterviews.js
+++ b/src/Services/fetchInterviews.js
@@ -1,0 +1,15 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+
+export const fetchInterviews = createAsyncThunk(
+  "interviews/fetchInterviews",
+  async () => {
+    const response = await fetch("/interviews.json");
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch videos");
+    }
+
+    const data = await response.json();
+    return data;
+  },
+);

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -15,6 +15,7 @@ import {
   VideoFirst,
   VideoFirstItem,
   InterviewSecond,
+  InterviewSecondItem,
   // TheoryFirst,
   // TestsFirst,
 } from "../Pages";
@@ -72,17 +73,23 @@ export const router = createBrowserRouter([
       {
         path: "gradingsecond",
         element: <GradingSecond />,
-        // children: [
-        //   {
-        //     path: "interviewsecond",
-        //     element: <InterviewSecond />,
-        //   },
-        // ],
+        children: [
+          {
+            path: "interviewsecond",
+            element: <InterviewSecond />,
+            children: [
+              {
+                path: ":id",
+                element: <InterviewSecondItem />,
+              },
+            ],
+          },
+        ],
       },
-      {
-        path: "interviewsecond",
-        element: <InterviewSecond />,
-      },
+      // {
+      //   path: "interviewsecond",
+      //   element: <InterviewSecond />,
+      // },
       {
         path: "gradingthird",
         element: <GradingThird />,

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -14,6 +14,7 @@ import {
   Profile,
   VideoFirst,
   VideoFirstItem,
+  InterviewSecond,
   // TheoryFirst,
   // TestsFirst,
 } from "../Pages";
@@ -71,6 +72,16 @@ export const router = createBrowserRouter([
       {
         path: "gradingsecond",
         element: <GradingSecond />,
+        // children: [
+        //   {
+        //     path: "interviewsecond",
+        //     element: <InterviewSecond />,
+        //   },
+        // ],
+      },
+      {
+        path: "interviewsecond",
+        element: <InterviewSecond />,
       },
       {
         path: "gradingthird",

--- a/src/app/store/index.js
+++ b/src/app/store/index.js
@@ -2,6 +2,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import userAuthSlice from "./slice/UserAuthSlice";
 import usersSlice from "./slice/UsersSlice";
 import { videosReducer } from "./slice/VideosSlice.js";
+import { interviewsReducer } from "./slice/InterviewsSlice.js";
 import middlewareUsers from "./middleware/middlewareUsers";
 import middlewareUserAuth from "./middleware/middlewareUsersAuth.js";
 import firebase from "firebase/compat/app";
@@ -21,6 +22,7 @@ export const store = configureStore({
     userAuth: userAuthSlice,
     users: usersSlice,
     videos: videosReducer,
+    interviews: interviewsReducer,
   },
   devTools: true,
   middleware: getDefaultMiddleware =>

--- a/src/app/store/slice/InterviewsSlice.js
+++ b/src/app/store/slice/InterviewsSlice.js
@@ -22,7 +22,7 @@ export const InterviewsSlice = createSlice({
         (state, action) => {
           state.status = "succeeded";
           state.error = null;
-          state.videos = action.payload;
+          state.interviews = action.payload;
         },
       )
       .addCase(
@@ -35,4 +35,4 @@ export const InterviewsSlice = createSlice({
   },
 });
 
-export const inerviewsReducer = InterviewsSlice.reducer;
+export const interviewsReducer = InterviewsSlice.reducer;

--- a/src/app/store/slice/InterviewsSlice.js
+++ b/src/app/store/slice/InterviewsSlice.js
@@ -1,0 +1,38 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { fetchInterviews } from "../../../Services/fetchInterviews";
+
+const initialState = {
+  interviews: [],
+  status: "idle", //"loading", "succeeded", "failed"
+  error: null,
+};
+
+export const InterviewsSlice = createSlice({
+  name: "interviews",
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchInterviews.pending, (state, action) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(
+        fetchInterviews.fulfilled,
+        (state, action) => {
+          state.status = "succeeded";
+          state.error = null;
+          state.videos = action.payload;
+        },
+      )
+      .addCase(
+        fetchInterviews.rejected,
+        (state, action) => {
+          state.status = "failed";
+          state.error = action.payload;
+        },
+      );
+  },
+});
+
+export const inerviewsReducer = InterviewsSlice.reducer;


### PR DESCRIPTION
Реализован новый компонент - IframePalyer, который использует YouTube IFrame API
(согласно ТЗ: видео собеседований должны быть реализованы на встроенном плеере YouTube).
Ранее для логики пагинации и прогресса использовались встроенные методы тега video.
С тегом iframe они не совместимы. Поэтому используются события  YouTube IFrame API.

Данные о видео сейчас хранятся в interviews.json. Добавлены 10 видео с собеседований.

Создан слайс InterviewSlice, и добавлена fetchTnterviews.
В роутере добавлен путь к собеседованиям через второй грейд. Путь динамический - меняется от id видео.

Страница InterviewsSecond собрана по аналогии с VideoFirst, с использованием плеера и ThemeNavBar.
В компонентах VideoPlayer и ThemeNavBar были исправлены статические ссылки на грейд на динамические.

![image](https://github.com/user-attachments/assets/d7fff005-e1d2-4955-8661-e6ec963fcf53)
![image](https://github.com/user-attachments/assets/007f37ce-0b57-48ea-9bf6-6b923ecfc040)
![image](https://github.com/user-attachments/assets/e529a80b-2298-4dbe-9e88-a4463f4c72c1)
